### PR TITLE
[xtext/ls] Made DiagramServerManager configurable via Guice.

### DIFF
--- a/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/DefaultDiagramModule.xtend
+++ b/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/DefaultDiagramModule.xtend
@@ -23,6 +23,7 @@ import org.eclipse.sprotty.ILayoutEngine
 import org.eclipse.sprotty.IModelUpdateListener
 import org.eclipse.sprotty.IPopupModelFactory
 import org.eclipse.sprotty.xtext.ls.DiagramServerManager
+import org.eclipse.sprotty.xtext.ls.IDiagramServerManager
 import org.eclipse.sprotty.xtext.tracing.ITraceProvider
 import org.eclipse.sprotty.xtext.tracing.XtextTraceProvider
 import org.eclipse.xtext.service.AbstractGenericModule
@@ -39,7 +40,7 @@ abstract class DefaultDiagramModule extends AbstractGenericModule {
 		LanguageAwareDiagramServer
 	}
 	
-	def bindIDiagramServerProvider() {
+	def Class<? extends IDiagramServerManager> bindIDiagramServerManager() {
 		DiagramServerManager
 	}
 	

--- a/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/ls/DiagramLanguageServer.xtend
+++ b/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/ls/DiagramLanguageServer.xtend
@@ -43,7 +43,7 @@ import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
  * the languages and diagram types in the language server. 
  * 
  * It uses {@link IDiagramServerFactory}s to instantiate language and diagramType specific 
- * {@link IDiagramServer}s, a {@link DiagramServerManager} to manage these instances and
+ * {@link IDiagramServer}s, a {@link IDiagramServerManager} to manage these instances and
  * a {@link DiagramUpdater} to sync the diagram with model changes.
  */
 @Log
@@ -54,7 +54,7 @@ class DiagramLanguageServer extends LanguageServerImpl implements DiagramServerE
 	
 	@Inject
 	@Accessors(PUBLIC_GETTER)
-	DiagramServerManager diagramServerManager
+	IDiagramServerManager diagramServerManager
 
 	@Inject
 	@Accessors(PUBLIC_GETTER)

--- a/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/ls/DiagramServerManager.xtend
+++ b/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/ls/DiagramServerManager.xtend
@@ -19,7 +19,6 @@ package org.eclipse.sprotty.xtext.ls
 import com.google.common.collect.HashMultimap
 import com.google.inject.Inject
 import com.google.inject.Singleton
-import java.util.Collection
 import java.util.List
 import java.util.Map
 import org.eclipse.sprotty.IDiagramServer
@@ -32,7 +31,7 @@ import org.eclipse.xtext.util.internal.Log
 
 @Log
 @Singleton
-class DiagramServerManager {
+class DiagramServerManager implements IDiagramServerManager {
 
 	// injecting this yields a ProvisionException
 	DiagramLanguageServer languageServer
@@ -41,18 +40,18 @@ class DiagramServerManager {
 
 	Map<String, IDiagramServer> clientId2diagramServer = newLinkedHashMap
 	
-	List<IDiagramServerFactory> diagramServerFactories 
+	List<IDiagramServerFactory> diagramServerFactories
 
-	def void initialize(DiagramLanguageServer languageServer) {
+	override initialize(DiagramLanguageServer languageServer) {
 		this.languageServer = languageServer
 	}
 
-	def List<? extends ILanguageAwareDiagramServer> findDiagramServersByUri(String uri) {
+	override findDiagramServersByUri(String uri) {
 		synchronized (clientId2diagramServer)
 			clientId2diagramServer.values.filter(ILanguageAwareDiagramServer).filter[sourceUri == uri].toList
 	}
 
-	def IDiagramServer getDiagramServer(String diagramType, String clientId) {
+	override getDiagramServer(String diagramType, String clientId) {
 		synchronized (clientId2diagramServer) {
 			val existingDiagramServer = clientId2diagramServer.get(clientId)
 			if (existingDiagramServer !== null) {
@@ -75,12 +74,12 @@ class DiagramServerManager {
 		}
 	}
 	
-	def void removeDiagramServer(String clientId) {
+	override removeDiagramServer(String clientId) {
 		synchronized (clientId2diagramServer)
 			clientId2diagramServer.remove(clientId)
 	}
 	
-	def Collection<? extends IDiagramServer> getDiagramServers() {
+	override getDiagramServers() {
 		clientId2diagramServer.values
 	}
 	

--- a/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/ls/IDiagramServerManager.xtend
+++ b/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/ls/IDiagramServerManager.xtend
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+package org.eclipse.sprotty.xtext.ls
+
+import java.util.Collection
+import java.util.List
+import org.eclipse.sprotty.IDiagramServer
+import org.eclipse.sprotty.xtext.ILanguageAwareDiagramServer
+
+interface IDiagramServerManager {
+	
+	def void initialize(DiagramLanguageServer languageServer)
+	
+	def List<? extends ILanguageAwareDiagramServer> findDiagramServersByUri(String uri)
+	
+	def IDiagramServer getDiagramServer(String diagramType, String clientId)
+	
+	def void removeDiagramServer(String clientId)
+	
+	def Collection<? extends IDiagramServer> getDiagramServers()
+}

--- a/org.eclipse.sprotty.xtext/src/test/java/org/eclipse/sprotty/xtext/test/AbstractDiagramServerTest.xtend
+++ b/org.eclipse.sprotty.xtext/src/test/java/org/eclipse/sprotty/xtext/test/AbstractDiagramServerTest.xtend
@@ -18,14 +18,16 @@ package org.eclipse.sprotty.xtext.test
 import com.google.inject.Inject
 import org.eclipse.sprotty.Action
 import org.eclipse.sprotty.ActionMessage
+import org.eclipse.sprotty.xtext.ls.DiagramLanguageServer
+import org.eclipse.sprotty.xtext.ls.DiagramServerManager
 import org.eclipse.sprotty.xtext.ls.DiagramServerModule
 import org.eclipse.sprotty.xtext.ls.DiagramUpdater
+import org.eclipse.sprotty.xtext.ls.IDiagramServerManager
 import org.eclipse.sprotty.xtext.testlanguage.diagram.TestDiagramUpdater
 import org.eclipse.sprotty.xtext.testlanguage.diagram.TestLanguageDiagramGenerator
 import org.eclipse.xtext.ide.server.UriExtensions
 import org.eclipse.xtext.testing.AbstractLanguageServerTest
 import org.eclipse.xtext.util.Modules2
-import org.eclipse.sprotty.xtext.ls.DiagramLanguageServer
 
 abstract class AbstractDiagramServerTest extends AbstractLanguageServerTest {
 	
@@ -44,6 +46,7 @@ abstract class AbstractDiagramServerTest extends AbstractLanguageServerTest {
 	override protected getServerModule() {
 		Modules2.mixin(super.serverModule, new DiagramServerModule, [
 			bind(DiagramUpdater).to(TestDiagramUpdater)
+			bind(IDiagramServerManager).to(DiagramServerManager)
 		])
 	}
 	


### PR DESCRIPTION
Pull request for issue #16 
Introduces the IDiagramServerManager interface and changed the occurrences of the default DiagramServerManager to that interface.

Signed-off-by: Niklas Rentz <nre@informatik.uni-kiel.de>