### PR TITLE
Exposed the server for subclasses.

### DIFF
--- a/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/launch/DiagramServerLauncher.xtend
+++ b/org.eclipse.sprotty.xtext/src/main/java/org/eclipse/sprotty/xtext/launch/DiagramServerLauncher.xtend
@@ -49,7 +49,7 @@ abstract class DiagramServerLauncher extends ServerLauncher {
 	public static val TRACE = '-trace'
 	public static val NO_VALIDATE = '-noValidate'
 
-	@Inject LanguageServerImpl languageServer
+	@Inject protected LanguageServerImpl languageServer
 
 	DiagramLanguageServerSetup setup
 	


### PR DESCRIPTION
Otherwise, subclasses cannot create the launcher in the overridden `createLauncher` method.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>