### PR TITLE
Set the version of lsp4j

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -23,5 +23,6 @@ ext.versions = [
     gson: '2.8.2',
     websocket: '1.0',
     log4j: '1.2.16',
-    junit: '4.12'
+    junit: '4.12',
+    lsp4j: '0.7.2'
 ]


### PR DESCRIPTION
Currently using the project as a maven dependency produces a warning that the pom for lsp4j cannot be found. 

`[WARNING] The POM for org.eclipse.lsp4j:org.eclipse.lsp4j:jar:null is missing, no dependency information available`

Would it be okay to set the version here in order to resolve this? I've set it to the latest version as ./gradlew build seems to resolve it to this one, but I'm not sure if this is correct.