### PR TITLE
Make updateSelection protected

### DIFF
--- a/org.eclipse.sprotty/src/main/java/org/eclipse/sprotty/DefaultDiagramServer.java
+++ b/org.eclipse.sprotty/src/main/java/org/eclipse/sprotty/DefaultDiagramServer.java
@@ -400,7 +400,7 @@ public class DefaultDiagramServer implements IDiagramServer {
 			fireSelectionChanged(action);
 	}
 
-	private void updateSelection(SModelRoot newRoot, boolean update, Action cause) {
+	protected void updateSelection(SModelRoot newRoot, boolean update, Action cause) {
 		boolean selectionChanged = false;
 		if (update) {
 			selectionChanged = selectedElements.retainAll(new SModelIndex(newRoot).allIds());


### PR DESCRIPTION
In our product we have more complex selection rules,
but this method being private we can't apply them on model rebuilds.