### PR TITLE
Fixed problem with parsing unknown properties

### DIFF
--- a/org.eclipse.sprotty.server/build.gradle
+++ b/org.eclipse.sprotty.server/build.gradle
@@ -21,4 +21,5 @@ dependencies {
     compile project(':org.eclipse.sprotty')
     compile "com.google.code.gson:gson:${versions.gson}"
     compile "javax.websocket:javax.websocket-api:${versions.websocket}"
+    testCompile "junit:junit:${versions.junit}"
 }

--- a/org.eclipse.sprotty.server/src/main/java/org/eclipse/sprotty/server/json/PropertyBasedTypeAdapter.java
+++ b/org.eclipse.sprotty.server/src/main/java/org/eclipse/sprotty/server/json/PropertyBasedTypeAdapter.java
@@ -80,13 +80,14 @@ public abstract class PropertyBasedTypeAdapter<T> extends TypeAdapter<T> {
 	
 	protected abstract T createInstance(String parameter);
 	
-	protected void assignProperty(T instance, String propertyName, JsonReader in) throws IllegalAccessException {
+	protected void assignProperty(T instance, String propertyName, JsonReader in) throws IllegalAccessException, IOException {
 		try {
 			Field field = findField(instance.getClass(), propertyName);
 			Object value = gson.fromJson(in, field.getGenericType());
 			field.set(instance, value);
 		} catch (NoSuchFieldException e) {
 			// Ignore this property
+			in.skipValue();
 		}
 	}
 	

--- a/org.eclipse.sprotty.server/src/test/java/org/eclipse/sprotty/server/json/PropertyBasedTypeAdapterTest.java
+++ b/org.eclipse.sprotty.server/src/test/java/org/eclipse/sprotty/server/json/PropertyBasedTypeAdapterTest.java
@@ -1,0 +1,87 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.sprotty.server.json;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+import static org.junit.Assert.*;
+
+public class PropertyBasedTypeAdapterTest {
+	
+	@Test
+	public void testParseKnownProperty() {
+		Gson gson = createGson();
+		TestType t = gson.fromJson("{\"disc\":\"B\",\"valB\":\"foo\"}", TestType.class);
+		assertTrue(t instanceof TestTypeB);
+		assertEquals("foo", ((TestTypeB) t).valB);
+	}
+	
+	@Test
+	public void testParseUnknownProperty() {
+		Gson gson = createGson();
+		TestType t = gson.fromJson("{\"disc\":\"B\",\"unknown\":\"foo\"}", TestType.class);
+		assertTrue(t instanceof TestTypeB);
+		assertNull(((TestTypeB) t).valB);
+	}
+	
+	static Gson createGson() {
+		return new GsonBuilder()
+				.registerTypeAdapterFactory(new TestTypeAdapter.Factory())
+				.create();
+	}
+	
+	static class TestTypeAdapter extends PropertyBasedTypeAdapter<TestType> {
+		static class Factory implements TypeAdapterFactory {
+			@Override
+			@SuppressWarnings("unchecked")
+			public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+				if (!TestType.class.equals(type.getRawType()))
+					return null;
+				return (TypeAdapter<T>) new TestTypeAdapter(gson);
+			}
+		}
+		
+		public TestTypeAdapter(Gson gson) {
+			super(gson, "disc");
+		}
+
+		@Override
+		protected TestType createInstance(String parameter) {
+			switch (parameter) {
+				case "A": return new TestTypeA();
+				case "B": return new TestTypeB();
+				default: throw new IllegalArgumentException();
+			}
+		}
+	}
+	
+	interface TestType {}
+	static class TestTypeA implements TestType {
+		String disc;
+		String valA;
+	}
+	static class TestTypeB implements TestType {
+		String disc;
+		String valB;
+	}
+
+}


### PR DESCRIPTION
I added a test that reveals a bug: without the fix to PropertyBasedTypeAdapter, parsing JSON with unknown properties leads to an IllegalStateException.