### PR TITLE
Support request rejection in diagram server

### DIFF
--- a/org.eclipse.sprotty.server/src/main/java/org/eclipse/sprotty/server/json/ActionTypeAdapter.java
+++ b/org.eclipse.sprotty.server/src/main/java/org/eclipse/sprotty/server/json/ActionTypeAdapter.java
@@ -30,6 +30,7 @@ import org.eclipse.sprotty.GetSelectionAction;
 import org.eclipse.sprotty.GetViewportAction;
 import org.eclipse.sprotty.LayoutAction;
 import org.eclipse.sprotty.OpenAction;
+import org.eclipse.sprotty.RejectAction;
 import org.eclipse.sprotty.RequestBoundsAction;
 import org.eclipse.sprotty.RequestExportSvgAction;
 import org.eclipse.sprotty.RequestModelAction;
@@ -89,6 +90,7 @@ public class ActionTypeAdapter extends PropertyBasedTypeAdapter<Action> {
 			addActionKind(GetViewportAction.KIND, GetViewportAction.class);
 			addActionKind(LayoutAction.KIND, LayoutAction.class);
 			addActionKind(OpenAction.KIND, OpenAction.class);
+			addActionKind(RejectAction.KIND, RejectAction.class);
 			addActionKind(RequestBoundsAction.KIND, RequestBoundsAction.class);
 			addActionKind(RequestExportSvgAction.KIND, RequestExportSvgAction.class);
 			addActionKind(RequestModelAction.KIND, RequestModelAction.class);

--- a/org.eclipse.sprotty/src/main/java/org/eclipse/sprotty/Actions.xtend
+++ b/org.eclipse.sprotty/src/main/java/org/eclipse/sprotty/Actions.xtend
@@ -50,6 +50,34 @@ interface ResponseAction extends Action {
 }
 
 /**
+ * A reject action is fired to indicate that a request must be rejected.
+ */
+@Accessors
+@EqualsHashCode
+@ToString(skipNulls = true)
+class RejectAction implements ResponseAction {
+	public static val KIND = 'rejectRequest'
+	String kind = KIND
+
+	String message
+	String responseId
+	Object detail
+	
+	new() {}
+	new(Consumer<RejectAction> initializer) {
+		initializer.accept(this)
+	}
+	new(String message, String responseId) {
+		this(message, responseId, null)
+	}
+	new(String message, String responseId, Object detail) {
+		this.message = message
+		this.responseId = responseId
+		this.detail = detail
+	}
+}
+
+/**
  * Wrapper for actions when transferring them between server and client via an {@link IDiagramServer}.
  */
 @Accessors
@@ -539,6 +567,11 @@ class GetSelectionAction implements RequestAction<SelectionResult> {
 	String kind = KIND
 
 	String requestId
+	
+	new() {}
+	new(Consumer<GetSelectionAction> initializer) {
+		initializer.accept(this)
+	}
 }
 
 @Accessors
@@ -550,6 +583,11 @@ class SelectionResult implements ResponseAction {
 
 	List<String> selectedElementsIDs
 	String responseId
+	
+	new() {}
+	new(Consumer<SelectionResult> initializer) {
+		initializer.accept(this)
+	}
 }
 
 /**
@@ -563,6 +601,11 @@ class GetViewportAction implements RequestAction<ViewportResult> {
 	String kind = KIND
 
 	String requestId
+	
+	new() {}
+	new(Consumer<GetViewportAction> initializer) {
+		initializer.accept(this)
+	}
 }
 
 @Accessors
@@ -575,4 +618,9 @@ class ViewportResult implements ResponseAction {
 	Viewport viewport
 	Bounds canvasBounds
 	String responseId
+	
+	new() {}
+	new(Consumer<ViewportResult> initializer) {
+		initializer.accept(this)
+	}
 }

--- a/org.eclipse.sprotty/src/main/java/org/eclipse/sprotty/util/RejectException.java
+++ b/org.eclipse.sprotty/src/main/java/org/eclipse/sprotty/util/RejectException.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.sprotty.util;
+
+import org.eclipse.sprotty.RejectAction;
+
+public class RejectException extends RuntimeException {
+
+	private static final long serialVersionUID = -4825580785369326949L;
+	
+	private final RejectAction action;
+	
+	public RejectException(RejectAction action) {
+		this.action = action;
+	}
+	
+	public RejectAction getAction() {
+		return action;
+	}
+
+}


### PR DESCRIPTION
Follow-up of https://github.com/eclipse/sprotty/pull/184. This adds support for rejecting RequestActions in both directions.