### PR TITLE
Made LayoutContext public

### DIFF
--- a/org.eclipse.sprotty.layout/src/main/java/org/eclipse/sprotty/layout/ElkLayoutEngine.java
+++ b/org.eclipse.sprotty.layout/src/main/java/org/eclipse/sprotty/layout/ElkLayoutEngine.java
@@ -549,7 +549,7 @@ public class ElkLayoutEngine implements ILayoutEngine {
 	/**
 	 * Data required for applying the computed ELK layout to the original sprotty model.
 	 */
-	protected static class LayoutContext {
+	public static class LayoutContext {
 		public SGraph sgraph;
 		public ElkNode elkGraph;
 		public final Map<SModelElement, SModelElement> parentMap = Maps.newHashMap();


### PR DESCRIPTION
This can be useful so an application may extract parts of the layout process to separate classes, e.g. layout configuration.